### PR TITLE
JSON (Metrics) Support

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -21,6 +21,8 @@ var (
 	showUnchanged bool
 	compact       bool
 	useMarkdown   bool
+	useJson       bool
+	metrics       bool
 )
 
 func init() {
@@ -28,20 +30,32 @@ func init() {
 	summarizeCmd.Flags().BoolVarP(&showUnchanged, "show-unchanged", "u", false, "Show resources with no changes")
 	summarizeCmd.Flags().BoolVarP(&compact, "compact", "c", false, "Use compact formatting")
 	summarizeCmd.Flags().BoolVarP(&useMarkdown, "markdown", "m", false, "Use markdown formatting")
+	summarizeCmd.Flags().BoolVarP(&useJson, "json", "j", false, "Use JSON output")
+	summarizeCmd.Flags().BoolVarP(&metrics, "metrics", "s", false, "Output metrics")
 }
 
-// summarizeCmd will parse the tf plan output json to scrape created|updated|deleted resources in a clear outout
+// summarizeCmd will parse the tf plan output useJson to scrape created|updated|deleted resources in a clear outout
 var summarizeCmd = &cobra.Command{
 	Use:   "summarize",
 	Short: "Get a summary of terraform/terragrunt output",
 	Long:  "Get a summary of terraform/terragrunt output plan (created|updated|destroyed...)",
 	Run: func(cmd *cobra.Command, args []string) {
+		if useMarkdown && useJson {
+			fmt.Println("-m (Markdown output) and -j (JSON output) are mutually exclusive")
+			os.Exit(1)
+		}
+
+		if metrics && !useJson {
+			fmt.Println("Metric output can only be used with JSON output")
+			os.Exit(1)
+		}
+
 		output, err := reader.Reader(os.Stdin)
 		if err != nil {
 			panic(err)
 		}
 
-		parser.Parser(output, showTags, showUnchanged, compact, useMarkdown)
+		parser.Parser(output, showTags, showUnchanged, compact, useMarkdown, useJson, metrics)
 	},
 }
 

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -34,7 +34,7 @@ func init() {
 	summarizeCmd.Flags().BoolVarP(&metrics, "metrics", "s", false, "Output metrics")
 }
 
-// summarizeCmd will parse the tf plan output useJson to scrape created|updated|deleted resources in a clear outout
+// summarizeCmd will parse the tf plan output json to scrape created|updated|deleted resources in a clear outout
 var summarizeCmd = &cobra.Command{
 	Use:   "summarize",
 	Short: "Get a summary of terraform/terragrunt output",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerscrew/tftools
 
-go 1.21.5
+go 1.21
 
 require (
 	github.com/charmbracelet/glamour v0.6.0

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -144,16 +144,12 @@ func PrintPlanSummary(showTags, showUnchanged, compact, useMarkdown bool, useJso
 	if !useJson {
 		if showUnchanged {
 			PrintResources("🔵 Unchanged:", resourcesList[NOOP], "•", color.New(color.FgBlue), compact, useMarkdown)
-			fmt.Println(",")
 		}
 		if showTags {
 			PrintResources("🟣 Tag/Untag:", resourcesList[TAG], "#", color.New(color.FgMagenta), compact, useMarkdown)
-			fmt.Println(",")
 		}
 		PrintResources("🟢 Create:", resourcesList[CREATE], "+", color.New(color.FgGreen), compact, useMarkdown)
-		fmt.Println(",")
 		PrintResources("🟡 Update:", resourcesList[UPDATE], "~", color.New(color.FgYellow), compact, useMarkdown)
-		fmt.Println(",")
 		PrintResources("🔴 Destroy:", resourcesList[DELETE], "-", color.New(color.FgRed), compact, useMarkdown)
 	} else {
 		PrintResourcesJson(showTags, showUnchanged, metrics)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -20,7 +20,7 @@ var (
 	resourcesList = make(map[string][]string)
 )
 
-func Parser(output []byte, showTags, showUnchanged, compact, useMarkdown bool) {
+func Parser(output []byte, showTags, showUnchanged, compact, useMarkdown bool, useJson bool, metrics bool) {
 	var data tfjson.Plan
 	if err := json.Unmarshal(output, &data); err != nil {
 		fmt.Printf("Error unmarshalling plan: %v\n", err)
@@ -31,7 +31,7 @@ func Parser(output []byte, showTags, showUnchanged, compact, useMarkdown bool) {
 		processResourceChange(resourceChange, showTags)
 	}
 
-	PrintPlanSummary(showTags, showUnchanged, compact, useMarkdown)
+	PrintPlanSummary(showTags, showUnchanged, compact, useMarkdown, useJson, metrics)
 }
 
 func processResourceChange(resourceChange *tfjson.ResourceChange, showTags bool) {
@@ -140,16 +140,70 @@ func PrintResources(message string, resources []string, bulletSymbol string, col
 	}
 }
 
-func PrintPlanSummary(showTags, showUnchanged, compact, useMarkdown bool) {
-	if showUnchanged {
-		PrintResources("🔵 Unchanged:", resourcesList[NOOP], "•", color.New(color.FgBlue), compact, useMarkdown)
+func PrintPlanSummary(showTags, showUnchanged, compact, useMarkdown bool, useJson bool, metrics bool) {
+	if !useJson {
+		if showUnchanged {
+			PrintResources("🔵 Unchanged:", resourcesList[NOOP], "•", color.New(color.FgBlue), compact, useMarkdown)
+			fmt.Println(",")
+		}
+		if showTags {
+			PrintResources("🟣 Tag/Untag:", resourcesList[TAG], "#", color.New(color.FgMagenta), compact, useMarkdown)
+			fmt.Println(",")
+		}
+		PrintResources("🟢 Create:", resourcesList[CREATE], "+", color.New(color.FgGreen), compact, useMarkdown)
+		fmt.Println(",")
+		PrintResources("🟡 Update:", resourcesList[UPDATE], "~", color.New(color.FgYellow), compact, useMarkdown)
+		fmt.Println(",")
+		PrintResources("🔴 Destroy:", resourcesList[DELETE], "-", color.New(color.FgRed), compact, useMarkdown)
+	} else {
+		PrintResourcesJson(showTags, showUnchanged, metrics)
 	}
-	if showTags {
-		PrintResources("🟣 Tag/Untag:", resourcesList[TAG], "#", color.New(color.FgMagenta), compact, useMarkdown)
+}
+
+func PrintResourcesJson(showTags bool, showUnchanged bool, metrics bool) {
+	if metrics {
+		var metricsData = make(map[string]int)
+
+		if showUnchanged {
+			metricsData["unchanged"] = len(resourcesList[NOOP])
+		}
+
+		if showTags {
+			metricsData["tag"] = len(resourcesList[TAG])
+		}
+
+		metricsData["create"] = len(resourcesList[CREATE])
+		metricsData["update"] = len(resourcesList[UPDATE])
+		metricsData["delete"] = len(resourcesList[DELETE])
+
+		result, _ := json.Marshal(metricsData)
+		fmt.Println(string(result))
+	} else {
+		var data = make(map[string][]string)
+
+		if showUnchanged && len(resourcesList[NOOP]) > 0 {
+			data["unchanged"] = resourcesList[NOOP]
+		}
+
+		if showTags && len(resourcesList[TAG]) > 0 {
+			data["tag"] = resourcesList[TAG]
+		}
+
+		if len(resourcesList[CREATE]) > 0 {
+			data["create"] = resourcesList[CREATE]
+		}
+
+		if len(resourcesList[UPDATE]) > 0 {
+			data["update"] = resourcesList[UPDATE]
+		}
+
+		if len(resourcesList[DELETE]) > 0 {
+			data["delete"] = resourcesList[DELETE]
+		}
+
+		result, _ := json.Marshal(data)
+		fmt.Println(string(result))
 	}
-	PrintResources("🟢 Create:", resourcesList[CREATE], "+", color.New(color.FgGreen), compact, useMarkdown)
-	PrintResources("🟡 Update:", resourcesList[UPDATE], "~", color.New(color.FgYellow), compact, useMarkdown)
-	PrintResources("🔴 Destroy:", resourcesList[DELETE], "-", color.New(color.FgRed), compact, useMarkdown)
 }
 
 func checkOnlyTagChanges(resourceChange *tfjson.ResourceChange) (bool, error) {


### PR DESCRIPTION
- Added `-j` option to enable JSON output
- Added `-s` option to enable JSON Metrics (this will count the resources)

If you have any comments, let me know!

Example JSON Output:

```json
{
  "create": [
    "module.router.module.postgresflexibleservers[\"auto-dba-0001\"].azurerm_key_vault_secret.flexible",
  ],
  "delete": [
    "module.router.module.confluent_topics[\"dummy-topic\"].confluent_kafka_acl.allow-read-on-group[\"sa-test-infra-app1\"]",
  ]
}
```

Example JSON Metric output:
```json
{
  "create": 53,
  "delete": 16,
  "tag": 0,
  "unchanged": 29,
  "update": 0
}
```